### PR TITLE
Lighting fixes and moved teleporter/orb

### DIFF
--- a/MonkeMapLoader/Behaviours/MapLoader.cs
+++ b/MonkeMapLoader/Behaviours/MapLoader.cs
@@ -365,6 +365,8 @@ namespace VmodMonkeMapLoader.Behaviours
 
                 _globalData.BigTreeTeleportToMap.layer = Constants.MaskLayerPlayerTrigger;
                 Object.DontDestroyOnLoad(_globalData.BigTreeTeleportToMap);
+                _globalData.BigTreeTeleportToMap.transform.position += new Vector3(0, -0.05f, 2.9f);
+                _globalData.BigTreeTeleportToMap.transform.Rotate(new Vector3(0, 20, 0));
             }
 
 

--- a/MonkeMapLoader/Behaviours/MapLoader.cs
+++ b/MonkeMapLoader/Behaviours/MapLoader.cs
@@ -66,6 +66,16 @@ namespace VmodMonkeMapLoader.Behaviours
 
         public static void JoinGame()
         {
+            try
+            {
+                //AdjustLighting(_mapInstance);
+            }
+            catch (Exception e)
+            {
+                Debug.Log("ERROR LOADING TEXTURES");
+                Debug.Log(e);
+            }
+
             if (!_lobbyName.IsNullOrWhiteSpace())
             {
                 Utilla.Utils.RoomUtils.JoinModdedLobby(_lobbyName);
@@ -275,10 +285,6 @@ namespace VmodMonkeMapLoader.Behaviours
             {
                 var child = parent.transform.GetChild(i).gameObject;
 
-                // Logger.LogText("Processing object: " + child.name);
-
-                //FixShader(child); <- this crashes for some reason.
-
                 SetupCollisions(child);
 
                 if (child.transform.childCount > 0)
@@ -293,6 +299,24 @@ namespace VmodMonkeMapLoader.Behaviours
                 {
                     teleporter.TeleportPoints = new List<Transform>() { _globalData.BigTreePoint.transform };
                     teleporter.TeleporterType = TeleporterType.Treehouse;
+                }
+            }
+        }
+
+        private static void AdjustLighting(GameObject child)
+        {
+            if(child != null)
+            {
+                var renderers = child.GetComponentsInChildren<Renderer>();
+                if (renderers == null) return;
+                foreach(var renderer in renderers)
+                {
+                    if (renderer == null) return;
+                    foreach(var material in renderer.materials)
+                    {
+                        if (material == null) return;
+                        LightingUtils.SetLightingStrength(material, 1f);
+                    }
                 }
             }
         }

--- a/MonkeMapLoader/Helpers/LightingUtils.cs
+++ b/MonkeMapLoader/Helpers/LightingUtils.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace VmodMonkeMapLoader.Helpers
+{
+    public static class LightingUtils
+    {
+        public static void SetLightingStrength(Material material, float strength)
+        {
+            // Strength = 1 means max lighting strength - unchanged from export
+            // Strength = 0 means no lighting (probably darkness)
+            if (material == null) return;
+            if (!material.HasProperty("_OcclusionMap")) return; // Non-standard shaders can't use occlusion maps
+            Texture map = material.GetTexture("_OcclusionMap"); // Get the occlusion map to check if it exists already
+            if (map != null && map.name.Contains("adjustedByLoader")) return; // No need to change if it's adjusted
+            else if (map != null) SetExistingLightingStrength(material, strength); // IF it's an occlusion map set by the map creator then more advanced logic is needed
+            else
+            {
+                Texture2D texture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
+                texture.name = material.name + "_OCC_adjustedByLoader";
+
+                texture.SetPixel(0, 0, new Color(strength, strength, strength, 1));
+                texture.Apply();
+
+                material.SetTexture("_OcclusionMap", texture);
+            }
+        }
+
+        public static void SetExistingLightingStrength(Material material, float strength)
+        {
+            // More advanced lighting logic that takes each pixel as a base and interpolates strength
+            if (material == null) return;
+            if (!material.HasProperty("_OcclusionMap")) return; // Non-standard shaders can't use occlusion maps
+
+            Texture map = material.GetTexture("_OcclusionMap"); // Get the occlusion map 
+            Texture2D duplicatedTexture = new Texture2D(map.width, map.height);
+            duplicatedTexture.name = map.name + "_adjustedByLoader";
+            Graphics.CopyTexture(map, duplicatedTexture);
+
+            // Iterate through each pixel and set them.
+            // Dunno how efficient this is but performance impact seems minimal and it's only done on load
+            for(int i = 0; i < duplicatedTexture.width; i++)
+            {
+                for(int j = 0; j < duplicatedTexture.height; j++)
+                {
+                    Color pixel = duplicatedTexture.GetPixel(i, j);
+
+                    Color updatedPixel = new Color(
+                        StrengthFromExistingColorFloat(pixel.r, strength),
+                        StrengthFromExistingColorFloat(pixel.g, strength),
+                        StrengthFromExistingColorFloat(pixel.b, strength),
+                        1
+                    );
+
+                    duplicatedTexture.SetPixel(i, j, updatedPixel);
+                }
+            }
+
+            duplicatedTexture.Apply();
+            material.SetTexture("_OcclusionMap", duplicatedTexture);
+        }
+
+        public static float StrengthFromExistingColorFloat(float colorValue, float strength)
+        {
+            // Color - (Color * (1 - Strength))
+            float manipulatedValue = colorValue - (colorValue * (1 - strength));
+            if (manipulatedValue < 0) manipulatedValue = 0;
+            return manipulatedValue;
+        }
+    }
+}

--- a/MonkeMapLoader/Helpers/LightingUtils.cs
+++ b/MonkeMapLoader/Helpers/LightingUtils.cs
@@ -37,11 +37,11 @@ namespace VmodMonkeMapLoader.Helpers
             Texture map = material.GetTexture("_OcclusionMap"); // Get the occlusion map 
             Texture2D duplicatedTexture = new Texture2D(map.width, map.height);
             duplicatedTexture.name = map.name + "_adjustedByLoader";
-            Color[] pixels = (map as Texture2D).GetPixels();
             Graphics.CopyTexture(map, duplicatedTexture);
+            Color[] pixels = duplicatedTexture.GetPixels();
 
             // Iterate through each pixel and set them.
-            for(int i = 0; i < pixels.Length; i++)
+            for (int i = 0; i < pixels.Length; i++)
             {
                 Color pixel = pixels[i];
 

--- a/MonkeMapLoader/Helpers/LightingUtils.cs
+++ b/MonkeMapLoader/Helpers/LightingUtils.cs
@@ -37,28 +37,24 @@ namespace VmodMonkeMapLoader.Helpers
             Texture map = material.GetTexture("_OcclusionMap"); // Get the occlusion map 
             Texture2D duplicatedTexture = new Texture2D(map.width, map.height);
             duplicatedTexture.name = map.name + "_adjustedByLoader";
+            Color[] pixels = (map as Texture2D).GetPixels();
             Graphics.CopyTexture(map, duplicatedTexture);
 
             // Iterate through each pixel and set them.
-            // Dunno how efficient this is but performance impact seems minimal and it's only done on load
-            for(int i = 0; i < duplicatedTexture.width; i++)
+            for(int i = 0; i < pixels.Length; i++)
             {
-                for(int j = 0; j < duplicatedTexture.height; j++)
-                {
-                    Color pixel = duplicatedTexture.GetPixel(i, j);
+                Color pixel = pixels[i];
 
-                    Color updatedPixel = new Color(
-                        StrengthFromExistingColorFloat(pixel.r, strength),
-                        StrengthFromExistingColorFloat(pixel.g, strength),
-                        StrengthFromExistingColorFloat(pixel.b, strength),
-                        1
-                    );
-
-                    duplicatedTexture.SetPixel(i, j, updatedPixel);
-                }
+                Color updatedPixel = new Color(
+                    StrengthFromExistingColorFloat(pixel.r, strength),
+                    StrengthFromExistingColorFloat(pixel.g, strength),
+                    StrengthFromExistingColorFloat(pixel.b, strength),
+                    1
+                );
+                pixels[i] = updatedPixel;
             }
 
-            duplicatedTexture.Apply();
+            duplicatedTexture.SetPixels(pixels);
             material.SetTexture("_OcclusionMap", duplicatedTexture);
         }
 

--- a/MonkeMapLoader/Helpers/LightingUtils.cs
+++ b/MonkeMapLoader/Helpers/LightingUtils.cs
@@ -55,6 +55,7 @@ namespace VmodMonkeMapLoader.Helpers
             }
 
             duplicatedTexture.SetPixels(pixels);
+            duplicatedTexture.Apply();
             material.SetTexture("_OcclusionMap", duplicatedTexture);
         }
 


### PR DESCRIPTION
- Added a way to modify lighting strength
   - Currently unused, just wanted to have it handy in case lemming updates lighting again and breaks map lighting
- Moved teleporter/orb to a better position that won't conflict with the canyon