### PR TITLE
Fix to make the trigger work again on round end

### DIFF
--- a/MonkeMapLoader/Behaviours/ObjectTrigger.cs
+++ b/MonkeMapLoader/Behaviours/ObjectTrigger.cs
@@ -22,6 +22,8 @@ namespace VmodMonkeMapLoader.Behaviours
         {
             if (!DisableObject) ObjectToTrigger.SetActive(false);
             else ObjectToTrigger.SetActive(true);
+            
+            _triggered = false;
         }
 
         public override void Trigger(Collider collider)


### PR DESCRIPTION
Triggers on pc dont reset properly after round end, rendering them useless after first being used
this was because the _triggered bool was not getting reset to false OnEnable